### PR TITLE
Replace exists() with existsSync() because exists() is deprecated.

### DIFF
--- a/lib/tree-ignore.coffee
+++ b/lib/tree-ignore.coffee
@@ -44,7 +44,7 @@ module.exports =
         @update()
 
     update: ->
-        return $( atom.views.getView( atom.workspace ) ).find( ".tree-view li.entry" ).removeClass "tree-ignore-element" unless _oAtomIgnoreFile.exists()
+        return $( atom.views.getView( atom.workspace ) ).find( ".tree-view li.entry" ).removeClass "tree-ignore-element" unless _oAtomIgnoreFile.existsSync()
         oIgnore = ignore().addIgnoreFile _oAtomIgnoreFile.getPath()
 
         $( atom.views.getView( atom.workspace ) ).find( ".tree-view li.entry .name" ).each ->

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/leny/atom-tree-ignore",
   "license": "MIT",
   "engines": {
-    "atom": ">=0.177.0"
+    "atom": ">=0.180.0"
   },
   "dependencies": {
     "fs-plus": "^2.4.0",


### PR DESCRIPTION
Atom started pulling in pathwatcher 3.3.1 in version 0.180.0:
https://github.com/atom/atom/commit/c260a29434547493d5f22508e2afd2da96f13f40
