### PR TITLE
Fix two usages of slashes

### DIFF
--- a/lib/tree-ignore.js
+++ b/lib/tree-ignore.js
@@ -11,7 +11,7 @@ let oPackageConfig,
     _oAtomIgnoreFile,
     _oMutationObserver,
     fActivate, fDeactivate,
-    _fUpdate, _fApply, _fTreeViewHasMutate;
+    _fUpdate, _fApply, _fTreeViewHasMutated;
 
 oPackageConfig = {
     "enabled": {
@@ -40,7 +40,7 @@ fActivate = function() {
 
     _bHideState = atom.config.get( "tree-ignore.enabled" ) || false;
 
-    _oMutationObserver = new MutationObserver( _fTreeViewHasMutate );
+    _oMutationObserver = new MutationObserver( _fTreeViewHasMutated );
 
     atom.packages.onDidActivateInitialPackages( () => {
         ( _oAtomIgnoreFile = new File( atom.project.resolvePath( atom.config.get( "tree-ignore.ignoreFileName" ) ) ) )
@@ -67,7 +67,7 @@ _fApply = function( bValue ) {
 };
 
 _fUpdate = function() {
-    let oIgnore;
+    let oIgnore, sProjectRoot;
 
     if ( _bHideState && document.querySelector( ".tree-view" ) ) {
         _oMutationObserver.observe( document.querySelector( ".tree-view" ), {
@@ -87,23 +87,32 @@ _fUpdate = function() {
 
     oIgnore = ignore().addIgnoreFile( _oAtomIgnoreFile.getPath() );
 
+    sProjectRoot = "";
+    aTreeEntries = [];
     $( atom.views.getView( atom.workspace ) )
         .find( ".tree-view li.entry .name" ).each( function() {
-            let sPath, $this;
+            let sPath, $this, aFiltered;
 
             if ( sPath = ( $this = $( this ) ).data( "path" ) ) {
-                atom.project.getPaths().map( ( sProjectPath ) => {
-                    sPath = sPath.replace( sProjectPath, "" );
-                } );
+                let $parent = $this.parents( "li.entry" ).first();
+
                 if ( _bIsWindowsPlatform ) {
                     sPath = sPath.replace( /\\/g, "/" );
                 }
-                $this.parents( "li.entry" ).first().toggleClass( "tree-ignore-element", _bHideState && !oIgnore.filter( [ sPath ] ).length );
+                if ( $parent.hasClass( "directory" ) ) {
+                    sPath += "/";
+                }
+                if ( $parent.hasClass( "project-root" ) ) {
+                    sProjectRoot = sPath;
+                }
+                sPath = sPath.substring( sProjectRoot.length );
+                aFiltered = oIgnore.filter( [ sPath ] );
+                $parent.toggleClass( "tree-ignore-element", _bHideState && !aFiltered.length );
             }
         } );
 };
 
-_fTreeViewHasMutate = function() {
+_fTreeViewHasMutated = function() {
     _fUpdate();
 };
 


### PR DESCRIPTION
- Initial slash means "match at root of project";
  handled by removing the path of the current project.
  Fixes #12 
- Trailing slash means "match only if directory";
  handled by adding a trailing slash to the path.
  Fixes #13 
