### PR TITLE
Support re-include syntax. Fix #8

### DIFF
--- a/lib/tree-ignore.js
+++ b/lib/tree-ignore.js
@@ -5,14 +5,14 @@ import { CompositeDisposable } from "atom";
 import $ from "jquery";
 
 let oPackageConfig,
-    oDisposables, oAtomIgnoreFileDisposables,
+    fActivate, fDeactivate,
+    _oDisposables, _oAtomIgnoreFileDisposables,
+    _oMutationObserver,
     _bIsWindowsPlatform = document.body.classList.contains( "platform-win32" ),
     _bEnabled,
     _oAtomIgnoreFiles,
-    _oMutationObserver,
-    fActivate, fDeactivate,
     _fUpdate, _fApply, _fTreeViewHasMutated, _fProjectChangedPaths,
-    _fAddAtomIgnoreFiles, _fNormalizePath, _fHandleIgnoreFile;
+    _fAddAtomIgnoreFiles, _fNormalizePath, _fHandleIgnoreFile, _fUnhideParents;
 
 oPackageConfig = {
     "enabled": {
@@ -26,16 +26,16 @@ oPackageConfig = {
 };
 
 fActivate = function() {
-    oDisposables && oDisposables.dispose();
-    oDisposables = new CompositeDisposable();
+    _oDisposables && _oDisposables.dispose();
+    _oDisposables = new CompositeDisposable();
 
-    oDisposables.add( atom.commands.add( "atom-workspace", {
+    _oDisposables.add( atom.commands.add( "atom-workspace", {
         "tree-ignore:toggle": _fApply.bind( null, !_bEnabled ),
         "tree-ignore:enable": _fApply.bind( null, true ),
         "tree-ignore:disable": _fApply.bind( null, false )
     } ) );
 
-    oDisposables.add( atom.commands.add( ".platform-win32, .platform-linux, .platform-darwin", {
+    _oDisposables.add( atom.commands.add( ".platform-win32, .platform-linux, .platform-darwin", {
         "tree-view:toggle": _fUpdate.bind( null )
     } ) );
 
@@ -44,7 +44,7 @@ fActivate = function() {
     _oMutationObserver = new MutationObserver( _fTreeViewHasMutated );
 
     atom.packages.onDidActivateInitialPackages( () => {
-        oDisposables.add( atom.project.onDidChangePaths( _fProjectChangedPaths ) );
+        _oDisposables.add( atom.project.onDidChangePaths( _fProjectChangedPaths ) );
 
         _fProjectChangedPaths();
 
@@ -59,8 +59,8 @@ fActivate = function() {
 };
 
 fDeactivate = function() {
-    oDisposables && oDisposables.dispose();
-    oAtomIgnoreFileDisposables && oAtomIgnoreFileDisposables.dispose();
+    _oDisposables && _oDisposables.dispose();
+    _oAtomIgnoreFileDisposables && _oAtomIgnoreFileDisposables.dispose();
     _oMutationObserver.disconnect();
 };
 
@@ -71,6 +71,7 @@ _fApply = function( bValue ) {
 
 _fUpdate = function() {
     let oIgnore,
+        oIgnoredItems = {},
         sProjectRoot = "",
         bHandleProject;
 
@@ -87,7 +88,7 @@ _fUpdate = function() {
         .find( ".tree-view li.entry .name" ).each( function() {
             let sPath,
                 $this,
-                aFiltered = [];
+                bFiltered = false;
 
             if ( sPath = ( $this = $( this ) ).data( "path" ) ) {
                 let $parent = $this.parents( "li.entry" ).first();
@@ -103,9 +104,16 @@ _fUpdate = function() {
                 }
                 if ( oIgnore !== null ) {
                     sPath = sPath.substring( sProjectRoot.length );
-                    aFiltered = oIgnore.filter( [ sPath ] );
+                    bFiltered = oIgnore.filter( [ sPath ] ).length === 0;
+                    if ( bFiltered ) {
+                        if ( sPath.endsWith( "/" ) ) {
+                            oIgnoredItems[ sPath ] = $parent;
+                        }
+                    } else {
+                        _fUnhideParents( oIgnoredItems, sPath );
+                    }
                 }
-                $parent.toggleClass( "tree-ignore-element", _bEnabled && bHandleProject && !aFiltered.length );
+                $parent.toggleClass( "tree-ignore-element", _bEnabled && bHandleProject && bFiltered );
             }
         } );
 };
@@ -122,15 +130,15 @@ _fProjectChangedPaths = function() {
 _fAddAtomIgnoreFiles = function() {
     let sIgnoreFileName = atom.config.get( "tree-ignore.ignoreFileName" );
 
-    oAtomIgnoreFileDisposables && oAtomIgnoreFileDisposables.dispose();
-    oAtomIgnoreFileDisposables = new CompositeDisposable();
+    _oAtomIgnoreFileDisposables && _oAtomIgnoreFileDisposables.dispose();
+    _oAtomIgnoreFileDisposables = new CompositeDisposable();
     _oAtomIgnoreFiles = {};
 
     atom.project.getDirectories().forEach( ( oDirectory ) => {
         let oIgnoreFile = oDirectory.getFile( sIgnoreFileName );
 
         _oAtomIgnoreFiles[ _fNormalizePath( `${ oDirectory.getPath() }/` ) ] = oIgnoreFile;
-        oAtomIgnoreFileDisposables.add( oIgnoreFile.onDidChange( _fUpdate ) );
+        _oAtomIgnoreFileDisposables.add( oIgnoreFile.onDidChange( _fUpdate ) );
     } );
 };
 
@@ -153,6 +161,24 @@ _fHandleIgnoreFile = function( sPath ) {
     }
 
     return ignore().addIgnoreFile( sIgnoreFile.getPath() );
+};
+
+_fUnhideParents = function( oIgnoredItems, sPath ) {
+    const getParent = function( sChildPath ) {
+        if ( sChildPath.endsWith( "/" ) ) {
+            return sChildPath.replace( /[^\/]*\/$/, "" );
+        }
+        return sChildPath.replace( /\/.*?$/, "/" );
+    };
+    let sParent = sPath, oItem;
+
+    while ( sParent.includes( "/" ) ) {
+        sParent = getParent( sParent );
+        oItem = oIgnoredItems[ sParent ];
+        if ( oItem !== undefined ) {
+            oItem.removeClass( "tree-ignore-element" );
+        }
+    }
 };
 
 export {


### PR DESCRIPTION
ignore library is a bit more permissive than git, I think.
See http://philhosoft.github.io/Software/Git%20gitignore%20rules/ where I checked rules for Git 2.7 (on Windows).
