### PR TITLE
Fix for uncaught type errors

### DIFF
--- a/lib/tree-ignore.js
+++ b/lib/tree-ignore.js
@@ -154,7 +154,8 @@ _fNormalizePath = function( sPath ) {
 };
 
 _fHandleIgnoreFile = function( sPath ) {
-    let sIgnoreFile = _oAtomIgnoreFiles[ sPath ];
+    let sIgnoreFile = _oAtomIgnoreFiles && _oAtomIgnoreFiles[ sPath ] ?
+        _oAtomIgnoreFiles[ sPath ] : null;
 
     if ( sIgnoreFile == null ) {
         // New root / project path, look if it has an ignore file


### PR DESCRIPTION
Ensure _OAtomIgnoreFiles has been initialized as an object before checking if a path is in it's keys.
