### PR TITLE
fixed ignoring '*' then negating didn't work

### DIFF
--- a/lib/tree-ignore.js
+++ b/lib/tree-ignore.js
@@ -106,7 +106,7 @@ _fUpdate = function() {
                     oIgnore = _fHandleIgnoreFile( sProjectRoot );
                     bHandleProject = oIgnore != null;
                 }
-                if ( oIgnore != null ) {
+                if ( oIgnore != null && sPath != sProjectRoot ) {
                     sPath = sPath.substring( sProjectRoot.length );
                     bFiltered = oIgnore.filter( [ sPath ] ).length === 0;
                     if ( bFiltered ) {


### PR DESCRIPTION
[The `.atomignore` file like this](http://stackoverflow.com/questions/987142/make-gitignore-ignore-everything-except-a-few-files) doesn't work, because once project root has been hidden, `_fUnhideParents` would not unhide it.

The ignore rules must not apply to project root. This is how Atom's core package `tree-view` works with `.gitignore`, and so should this one.
