### PR TITLE
Upgrade ignore to 3.x

### DIFF
--- a/lib/tree-ignore.js
+++ b/lib/tree-ignore.js
@@ -1,5 +1,6 @@
 "use babel";
 
+import * as fs from "fs";
 import ignore from "ignore";
 import { CompositeDisposable } from "atom";
 import $ from "jquery";
@@ -107,8 +108,8 @@ _fUpdate = function() {
                     bHandleProject = oIgnore != null;
                 }
                 if ( oIgnore != null ) {
-                    sPath = sPath.substring( sProjectRoot.length );
-                    bFiltered = oIgnore.filter( [ sPath ] ).length === 0;
+                    sPath = sPath.substring( sProjectRoot.length ).trim();
+                    bFiltered = sPath.length > 0 && oIgnore.filter( [ sPath ] ).length === 0;
                     if ( bFiltered ) {
                         if ( sPath.endsWith( "/" ) ) {
                             oIgnoredItems[ sPath ] = $parent;
@@ -165,7 +166,7 @@ _fHandleIgnoreFile = function( sPath ) {
         return null; // Removed, unhide everything
     }
 
-    return ignore().addIgnoreFile( sIgnoreFile.getPath() );
+    return ignore().add(fs.readFileSync(sIgnoreFile.getPath()).toString());
 };
 
 _fUnhideParents = function( oIgnoredItems, sPath ) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tree-ignore",
   "main": "./lib/tree-ignore",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Use a .atomignore file to hide files & folder in tree view",
   "repository": "https://github.com/leny/atom-tree-ignore",
   "license": "MIT",
@@ -9,7 +9,7 @@
     "atom": ">=0.199.0"
   },
   "dependencies": {
-    "ignore": "^2.2.15",
+    "ignore": "^3.2.0",
     "jquery": "^2.1.4"
   }
 }


### PR DESCRIPTION
Upgrading the ignore package to provide better consistency with modern
gitignore rules. This allows recursive ignore rules, among other things.

Also required a small edit to ensure that empty paths are filtered out
when hiding elements in the tree. It would appear that previously, an
unintended side-effect of the way ignore.filter worked filtered these
out; now its just explicit.